### PR TITLE
Added date and month to output

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -42,7 +42,11 @@ function update_time() {
     var now = new Date();
     now.setHours(now.getUTCHours());
     now.setMinutes(now.getUTCMinutes());
-    time_format_string = seconds_displayed ? '%T' : '%H:%M';
+    now.setDate(now.getUTCDate());
+    now.setMonth(now.getUTCMonth());
+
+    time_format_string = seconds_displayed ? '%T' :'%m-%d %H:%M';
+
     time_string = Shell.util_format_date(time_format_string, now);
     label.set_text(time_string + ' UTC');
 }


### PR DESCRIPTION
As I am a swing, grave, day shift worker UTC will change days before local time does and its nice for a quick ref for "Monitor until 1-14 15:42 UTC" messages for next few crew on the following days.

https://i.imgur.com/cZJf6nc.png